### PR TITLE
Temporarily remove 'validate' in compilePropertyBridges (Refs d2rq#194)

### DIFF
--- a/src/de/fuberlin/wiwiss/d2rq/map/Mapping.java
+++ b/src/de/fuberlin/wiwiss/d2rq/map/Mapping.java
@@ -198,7 +198,16 @@ public class Mapping {
 	}
 
 	private void compilePropertyBridges() {
-		validate();
+		/**
+		 * validate temporarily disabled, see bug
+		 * https://github.com/d2rq/d2rq/issues/194
+		 *
+		 * Not adding tests since new development in other branch
+		 * but this patch reduces test errors from 92 to 38
+
+		 validate();
+
+		 */
 		compiledPropertyBridges = new ArrayList<TripleRelation>();
 		for (ClassMap classMap: classMaps.values()) {
 			this.compiledPropertyBridges.addAll(classMap.compiledPropertyBridges());


### PR DESCRIPTION
Work around for issue https://github.com/d2rq/d2rq/issues/194

I did not add tests, but this patch reduces the amount of test errors from 92 to 38, so it seems a move in the good direction.

Also I can now successfully run

./d2r-server chembl_postgresql.ttl

Thanks upfront for reviewing my pull request (while it is only a work around).
