### PR TITLE
Free text search in PostgreSQL, Oracle and MySQL.

### DIFF
--- a/src/de/fuberlin/wiwiss/d2rq/D2RQException.java
+++ b/src/de/fuberlin/wiwiss/d2rq/D2RQException.java
@@ -99,6 +99,7 @@ public class D2RQException extends JenaException {
 	public static final int PROPERTYBRIDGE_MISSING_PREDICATESPEC = 85;
 	public static final int SQL_COLUMN_NOT_FOUND = 86;
 	public static final int STARTUP_UNKNOWN_FORMAT = 87;
+	public static final int DATABASE_DOES_NOT_SUPPORT_FREE_TEXT_SEARCH = 88;
 	
 	private int code;
 	

--- a/src/de/fuberlin/wiwiss/d2rq/expr/AttributeExpr.java
+++ b/src/de/fuberlin/wiwiss/d2rq/expr/AttributeExpr.java
@@ -19,6 +19,10 @@ public class AttributeExpr extends Expression {
 		return Collections.singleton(attribute);
 	}
 
+	public Attribute attribute() {
+		return this.attribute;
+	}
+
 	public boolean isFalse() {
 		return false;
 	}
@@ -27,7 +31,7 @@ public class AttributeExpr extends Expression {
 		return false;
 	}
 
-	public Expression renameAttributes(ColumnRenamer columnRenamer) {
+	public AttributeExpr renameAttributes(ColumnRenamer columnRenamer) {
 		return new AttributeExpr(columnRenamer.applyTo(attribute));
 	}
 

--- a/src/de/fuberlin/wiwiss/d2rq/expr/TextMatches.java
+++ b/src/de/fuberlin/wiwiss/d2rq/expr/TextMatches.java
@@ -1,0 +1,63 @@
+package de.fuberlin.wiwiss.d2rq.expr;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import de.fuberlin.wiwiss.d2rq.algebra.AliasMap;
+import de.fuberlin.wiwiss.d2rq.algebra.Attribute;
+import de.fuberlin.wiwiss.d2rq.algebra.ColumnRenamer;
+import de.fuberlin.wiwiss.d2rq.sql.ConnectedDB;
+
+public class TextMatches extends Expression {
+
+	protected final AttributeExpr expr1;
+	protected final Expression expr2;
+
+	private final Set<Attribute> columns = new HashSet<Attribute>();
+
+	public TextMatches(AttributeExpr expr1, Expression expr2) {
+		this.expr1 = expr1;
+		this.expr2 = expr2;
+		columns.addAll(expr1.attributes());
+		columns.addAll(expr2.attributes());
+	}
+
+	public Set<Attribute> attributes() {
+		return columns;
+	}
+
+	public boolean isFalse() {
+		return false;
+	}
+
+	public boolean isTrue() {
+		return false;
+	}
+
+	public TextMatches renameAttributes(ColumnRenamer columnRenamer) {
+		return new TextMatches(expr1.renameAttributes(columnRenamer), expr2.renameAttributes(columnRenamer));
+	}
+
+	public String toSQL(ConnectedDB database, AliasMap aliases) {
+		return database.vendor().freeTextExpression(
+			expr1.toSQL(database, aliases),
+			expr2.toSQL(database, aliases));
+	}
+
+	public String toString() {
+		return "<TextMatches> (" + expr1 + ", " + expr2 + ")";
+	}
+
+	public boolean equals(Object other) {
+		if (!(other instanceof TextMatches)) {
+			return false;
+		}
+		TextMatches otherTextMatches = (TextMatches) other;
+
+		return expr1.equals(otherTextMatches.expr1) && expr2.equals(otherTextMatches.expr2);
+	}
+
+	public int hashCode() {
+		return expr1.hashCode() ^ expr2.hashCode();
+	}
+}

--- a/src/de/fuberlin/wiwiss/d2rq/sql/vendor/MySQL.java
+++ b/src/de/fuberlin/wiwiss/d2rq/sql/vendor/MySQL.java
@@ -64,6 +64,16 @@ public class MySQL extends SQL92 {
 	}
 
 	@Override
+	public Boolean supportsFreeTextSearch() {
+		return true;
+	}
+
+	@Override
+	public String freeTextExpression(String textExpr, String query) {
+		return "MATCH (" + textExpr + ") AGAINST (" + query + ")";
+	}
+
+	@Override
 	// TODO: The MySQL JDBC driver reports TINYINT(1) as BIT, should be handled as xsd:boolean?
 	public DataType getDataType(int jdbcType, String name, int size) {
 

--- a/src/de/fuberlin/wiwiss/d2rq/sql/vendor/Oracle.java
+++ b/src/de/fuberlin/wiwiss/d2rq/sql/vendor/Oracle.java
@@ -55,6 +55,16 @@ public class Oracle extends SQL92 {
 	}
 
 	@Override
+	public Boolean supportsFreeTextSearch() {
+		return true;
+	}
+
+	@Override
+	public String freeTextExpression(String textExpr, String query) {
+		return "CATSEARCH(" + textExpr + ", " + query + ", '') > 0";
+	}
+
+	@Override
 	public DataType getDataType(int jdbcType, String name, int size) {
 		
 		// Doesn't support DISTINCT over LOB types

--- a/src/de/fuberlin/wiwiss/d2rq/sql/vendor/PostgreSQL.java
+++ b/src/de/fuberlin/wiwiss/d2rq/sql/vendor/PostgreSQL.java
@@ -23,6 +23,16 @@ public class PostgreSQL extends SQL92 {
 	}
 
 	@Override
+	public Boolean supportsFreeTextSearch() {
+		return true;
+	}
+
+	@Override
+	public String freeTextExpression(String textExpr, String query) {
+		return "to_tsvector('english', " + textExpr + ") @@ plainto_tsquery('english', " + query + ")";
+	}
+
+	@Override
 	public DataType getDataType(int jdbcType, String name, int size) {
 		DataType standard = super.getDataType(jdbcType, name, size);
 		if (standard != null) return standard;

--- a/src/de/fuberlin/wiwiss/d2rq/sql/vendor/SQL92.java
+++ b/src/de/fuberlin/wiwiss/d2rq/sql/vendor/SQL92.java
@@ -98,6 +98,14 @@ public class SQL92 implements Vendor {
 		return "TIMESTAMP " + quoteStringLiteral(timestamp);
 	}
 
+	public Boolean supportsFreeTextSearch() {
+		return false;
+	}
+
+	public String freeTextExpression(String textExpr, String query) {
+		throw new UnsupportedOperationException("Database does not support free text search");
+	}
+
 	public Expression getRowNumLimitAsExpression(int limit) {
 		return Expression.TRUE;
 	}

--- a/src/de/fuberlin/wiwiss/d2rq/sql/vendor/Vendor.java
+++ b/src/de/fuberlin/wiwiss/d2rq/sql/vendor/Vendor.java
@@ -92,7 +92,11 @@ public interface Vendor {
 	String quoteTimeLiteral(String time);
 	
 	String quoteTimestampLiteral(String timestamp);
+
+	Boolean supportsFreeTextSearch();
 	
+	String freeTextExpression(String textExpr, String query);
+
 	/**
 	 * Returns an expression for limiting the number of returned rows
 	 * for engines that support this (<code>ROWNUM &lt;= n</code>)

--- a/test/de/fuberlin/wiwiss/d2rq/engine/MapFixture.java
+++ b/test/de/fuberlin/wiwiss/d2rq/engine/MapFixture.java
@@ -11,8 +11,11 @@ import com.hp.hpl.jena.vocabulary.RDF;
 
 import de.fuberlin.wiwiss.d2rq.D2RQTestSuite;
 import de.fuberlin.wiwiss.d2rq.algebra.TripleRelation;
+import de.fuberlin.wiwiss.d2rq.map.Database;
 import de.fuberlin.wiwiss.d2rq.map.Mapping;
 import de.fuberlin.wiwiss.d2rq.parser.MapParser;
+import de.fuberlin.wiwiss.d2rq.sql.ConnectedDB;
+import de.fuberlin.wiwiss.d2rq.sql.DummyDB;
 import de.fuberlin.wiwiss.d2rq.vocab.D2RQ;
 import de.fuberlin.wiwiss.d2rq.vocab.Test;
 
@@ -36,11 +39,18 @@ public class MapFixture {
 	}
 	
 	public static Collection<TripleRelation> loadPropertyBridges(String mappingFileName) {
+		return loadPropertyBridges(mappingFileName, new DummyDB());
+	}
+
+	public static Collection<TripleRelation> loadPropertyBridges(String mappingFileName, ConnectedDB database) {
 		Model m = ModelFactory.createDefaultModel();
 		Resource dummyDB = m.getResource(Test.DummyDatabase.getURI());
 		dummyDB.addProperty(RDF.type, D2RQ.Database);
 		m.read(D2RQTestSuite.class.getResourceAsStream(mappingFileName), null, "TURTLE");
 		Mapping mapping = new MapParser(m, null).parse();
+		for (Database db: mapping.databases()) {
+			db.useConnectedDB(database);
+		}
 		return mapping.compiledPropertyBridges();
 	}
 }

--- a/test/de/fuberlin/wiwiss/d2rq/expr/ExpressionTest.java
+++ b/test/de/fuberlin/wiwiss/d2rq/expr/ExpressionTest.java
@@ -9,6 +9,7 @@ import de.fuberlin.wiwiss.d2rq.algebra.RelationName;
 import de.fuberlin.wiwiss.d2rq.sql.DummyDB;
 import de.fuberlin.wiwiss.d2rq.sql.SQL;
 import de.fuberlin.wiwiss.d2rq.sql.types.DataType.GenericType;
+import de.fuberlin.wiwiss.d2rq.sql.vendor.Vendor;
 
 /**
  * @author Richard Cyganiak (richard@cyganiak.de)
@@ -82,5 +83,14 @@ public class ExpressionTest extends TestCase {
 		Attribute attribute = SQL.parseAttribute("table.col1");
 		assertEquals("Constant(42@alias.col1)", 
 				new Constant("42", attribute).renameAttributes(aliases).toString());
+	}
+
+	public void testTextMatchesToSQL() {
+		TextMatches expr = new TextMatches(
+				new AttributeExpr(SQL.parseAttribute("table.col1")),
+			   	new Constant("some text"));
+		DummyDB db = new DummyDB(Vendor.PostgreSQL);
+		assertEquals("to_tsvector('english', \"table\".\"col1\") @@ plainto_tsquery('english', 'some text')",
+			   	expr.toSQL(db, AliasMap.NO_ALIASES));
 	}
 }

--- a/test/de/fuberlin/wiwiss/d2rq/optimizer/AllTests.java
+++ b/test/de/fuberlin/wiwiss/d2rq/optimizer/AllTests.java
@@ -9,6 +9,8 @@ public class AllTests {
 		TestSuite suite = new TestSuite(AllTests.class.getName());
 		//$JUnit-BEGIN$
 		suite.addTestSuite(ExprTransformTest.class);
+		suite.addTestSuite(ExprTransformTest2.class);
+		suite.addTestSuite(TextMatchesExprTransformTest.class);
 		//$JUnit-END$
 		return suite;
 	}

--- a/test/de/fuberlin/wiwiss/d2rq/optimizer/TextMatchesExprTransformTest.java
+++ b/test/de/fuberlin/wiwiss/d2rq/optimizer/TextMatchesExprTransformTest.java
@@ -1,0 +1,194 @@
+package de.fuberlin.wiwiss.d2rq.optimizer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+import com.hp.hpl.jena.graph.Node;
+import com.hp.hpl.jena.graph.Triple;
+import com.hp.hpl.jena.query.QueryBuildException;
+import com.hp.hpl.jena.sparql.expr.E_Function;
+import com.hp.hpl.jena.sparql.expr.Expr;
+import com.hp.hpl.jena.sparql.expr.ExprList;
+import com.hp.hpl.jena.sparql.expr.ExprVar;
+import com.hp.hpl.jena.sparql.expr.NodeValue;
+import com.hp.hpl.jena.vocabulary.RDF;
+import com.hp.hpl.jena.vocabulary.RDFS;
+
+import de.fuberlin.wiwiss.d2rq.D2RQException;
+import de.fuberlin.wiwiss.d2rq.algebra.Attribute;
+import de.fuberlin.wiwiss.d2rq.algebra.NodeRelation;
+import de.fuberlin.wiwiss.d2rq.algebra.ProjectionSpec;
+import de.fuberlin.wiwiss.d2rq.engine.GraphPatternTranslator;
+import de.fuberlin.wiwiss.d2rq.engine.MapFixture;
+import de.fuberlin.wiwiss.d2rq.expr.AttributeExpr;
+import de.fuberlin.wiwiss.d2rq.expr.Constant;
+import de.fuberlin.wiwiss.d2rq.expr.TextMatches;
+import de.fuberlin.wiwiss.d2rq.expr.Expression;
+import de.fuberlin.wiwiss.d2rq.optimizer.expr.TransformExprToSQLApplyer;
+import de.fuberlin.wiwiss.d2rq.sql.ConnectedDB;
+import de.fuberlin.wiwiss.d2rq.sql.DummyDB;
+import de.fuberlin.wiwiss.d2rq.sql.types.DataType.GenericType;
+import de.fuberlin.wiwiss.d2rq.sql.vendor.Vendor;
+
+public class TextMatchesExprTransformTest extends TestCase {
+
+	private static final String FUNCTION_URI = "http://d2rq.org/function#textMatches";
+	private static final String MAPPING_FILE = "optimizer/filtertests.n3";
+
+	public void testTexualColumn() {
+		Collection<NodeRelation> rels = translate(pattern(), MAPPING_FILE, new DummyDB(Vendor.PostgreSQL));
+
+		NodeRelation label = search("table1", "label", rels);
+
+		TextMatches expected = 
+			new TextMatches(
+				new AttributeExpr(new Attribute(null, "table1", "label")),
+				new Constant("something"));
+
+		Expression result = TransformExprToSQLApplyer.convert(textMatchesExpr(), label);
+
+		assertEquals(expected, result);
+	}
+
+	public void testNonTextualColumn() {
+		HashMap<String,GenericType> columnTypes = new HashMap<String,GenericType>();
+		columnTypes.put("table1.label", GenericType.NUMERIC);
+
+		Collection<NodeRelation> rels = translate(pattern(), MAPPING_FILE, new DummyDB(Vendor.PostgreSQL, columnTypes));
+
+		NodeRelation label = search("table1", "label", rels);
+
+		Expression result = TransformExprToSQLApplyer.convert(textMatchesExpr(), label);
+
+		assertEquals(Expression.FALSE, result);
+	}
+
+	public void testConstantValue() {
+		List<Triple> pattern = new ArrayList<Triple>();
+		pattern.add(Triple.create(Node.createVariable("s"), RDF.type.asNode(), Node.createVariable("o")));
+
+		Collection<NodeRelation> rels = translate(pattern, MAPPING_FILE, new DummyDB(Vendor.PostgreSQL));
+
+		NodeRelation type = search("table1", "id", rels);
+
+		Expression result = TransformExprToSQLApplyer.convert(textMatchesExpr(), type);
+
+		assertEquals(Expression.FALSE, result);
+	}
+
+	public void testSQLExpressionColumn() {
+		List<Triple> pattern = new ArrayList<Triple>();
+		pattern.add(Triple.create(Node.createVariable("s"), Node.createURI("http://example.org/computed"), Node.createVariable("o")));
+
+		Collection<NodeRelation> rels = translate(pattern, MAPPING_FILE, new DummyDB(Vendor.PostgreSQL));
+
+		NodeRelation value = rels.iterator().next();
+
+		Expression result = TransformExprToSQLApplyer.convert(textMatchesExpr(), value);
+
+		assertEquals(Expression.FALSE, result);
+	}
+
+	public void testUnsupportedDatabase() {
+		Collection<NodeRelation> rels = translate(pattern(), MAPPING_FILE, new DummyDB(Vendor.SQL92));
+
+		NodeRelation label = search("table1", "label", rels);
+
+		try {
+			TransformExprToSQLApplyer.convert(textMatchesExpr(), label);
+			fail("Should have failed because database does not support free text search");
+		} catch (D2RQException e) {
+			assertEquals(D2RQException.DATABASE_DOES_NOT_SUPPORT_FREE_TEXT_SEARCH, e.errorCode());
+		}
+	}
+
+	public void testQueryIsVariable() {
+		testInvalidArgumentTypes(new ExprVar("o"), new ExprVar("q"));
+	}
+
+	public void testQueryIsNoString() {
+		testInvalidArgumentTypes(new ExprVar("o"), NodeValue.makeNodeInteger(1));
+	}
+
+	public void testNoVariable() {
+		testInvalidArgumentTypes(NodeValue.makeNodeString("literal text"), NodeValue.makeNodeString("match"));
+	}
+
+	private void testInvalidArgumentTypes(Expr arg1, Expr arg2) {
+		Collection<NodeRelation> rels = translate(pattern(), MAPPING_FILE, new DummyDB(Vendor.PostgreSQL));
+
+		NodeRelation label = search("table1", "label", rels);
+
+		try {
+			ExprList arguments = new ExprList();
+			arguments.add(arg1);
+			arguments.add(arg2);
+			Expr textMatches = new E_Function(FUNCTION_URI, arguments);
+			TransformExprToSQLApplyer.convert(textMatches, label);
+			fail("Should have failed because invalid argument types");
+		} catch (QueryBuildException e) {
+			assertEquals("Function 'textMatches' takes a variable and a string", e.getMessage());
+		}
+	}
+
+	public void testNoArguments() {
+		testInvalidNumberOfArguments(new ExprList());
+	}
+
+	public void test1Argument() {
+		testInvalidNumberOfArguments(new ExprList(new ExprVar("o")));
+	}
+
+	public void test3Arguments() {
+		ExprList arguments = new ExprList(textMatchesExpr().getArgs());
+		arguments.add(new ExprVar("x"));
+		testInvalidNumberOfArguments(arguments);
+	}
+
+	private void testInvalidNumberOfArguments(ExprList arguments) {
+		Collection<NodeRelation> rels = translate(pattern(), MAPPING_FILE, new DummyDB(Vendor.PostgreSQL));
+
+		NodeRelation label = search("table1", "label", rels);
+		E_Function textMatches = new E_Function(FUNCTION_URI, arguments);
+
+		try {
+			TransformExprToSQLApplyer.convert(textMatches, label);
+			fail("Should have failed because wrong number of arguments given");
+		} catch (QueryBuildException e) {
+			assertEquals("Function 'textMatches' takes two arguments", e.getMessage());
+		}
+	}
+
+	private List<Triple> pattern() {
+		List<Triple> pattern = new ArrayList<Triple>();
+		pattern.add(Triple.create(Node.createVariable("s"), RDFS.label.asNode(), Node.createVariable("o")));
+		return pattern;
+	}
+
+	private E_Function textMatchesExpr() {
+		ExprList args = new ExprList();
+		args.add(new ExprVar("o"));
+		args.add(NodeValue.makeNodeString("something"));
+		return new E_Function(FUNCTION_URI, args);
+	}
+
+	private Collection<NodeRelation> translate(List<Triple> pattern, String mappingFile, ConnectedDB database) {
+		return new GraphPatternTranslator(pattern, MapFixture.loadPropertyBridges(mappingFile, database), true).translate();
+	}
+
+	private NodeRelation search(String tableName, String attributeName, Collection<NodeRelation> relations) {
+		for (NodeRelation rel : relations) {
+			for (ProjectionSpec p: rel.baseRelation().projections()) {
+				Attribute attribute = (Attribute) p;
+				if (attribute.tableName().equals(tableName) && attribute.attributeName().equals(attributeName))
+					return rel;
+			}
+		}
+		
+		return null;
+	}
+}

--- a/test/de/fuberlin/wiwiss/d2rq/optimizer/filtertests.n3
+++ b/test/de/fuberlin/wiwiss/d2rq/optimizer/filtertests.n3
@@ -50,3 +50,8 @@ map:Bridge5 a d2rq:PropertyBridge;
 	d2rq:column "table2.value";
 	.
 	
+map:Bridge6 a d2rq:PropertyBridge;
+	d2rq:belongsToClassMap map:Table2;
+	d2rq:property ex:computed;
+	d2rq:sqlExpression "table2.value + 1";
+	.

--- a/test/de/fuberlin/wiwiss/d2rq/sql/DummyDB.java
+++ b/test/de/fuberlin/wiwiss/d2rq/sql/DummyDB.java
@@ -23,8 +23,12 @@ public class DummyDB extends ConnectedDB {
 	}
 
 	public DummyDB(Map<String,GenericType> overrideColumnTypes) {
+		this(Vendor.SQL92, overrideColumnTypes);
+	}
+
+	public DummyDB(final Vendor vendor, Map<String,GenericType> overrideColumnTypes) {
 		super(null, null, null, overrideColumnTypes, Database.NO_LIMIT, Database.NO_FETCH_SIZE, null);
-		this.vendor = Vendor.SQL92;
+		this.vendor = vendor;
 	}
 	
 	public void setLimit(int newLimit) {

--- a/test/de/fuberlin/wiwiss/d2rq/sql/SQLBuildingTest.java
+++ b/test/de/fuberlin/wiwiss/d2rq/sql/SQLBuildingTest.java
@@ -124,4 +124,32 @@ public class SQLBuildingTest extends TestCase {
 		assertEquals("SELECT DISTINCT \"table\".\"foo\" FROM \"table\" WHERE (ROWNUM <= 100)",
 				new SelectStatementBuilder(r).getSQLStatement());
 	}
+
+	public void testFreeTextExpressionPostreSQL() {
+		Vendor db = Vendor.PostgreSQL;
+		assertEquals("to_tsvector('english', some attribute sql) @@ plainto_tsquery('english', some query)",
+				db.freeTextExpression("some attribute sql", "some query"));
+	}
+
+	public void testFreeTextExpressionOracle() {
+		Vendor db = Vendor.Oracle;
+		assertEquals("CATSEARCH(some attribute sql, some query, '') > 0",
+				db.freeTextExpression("some attribute sql", "some query"));
+	}
+
+	public void testFreeTextExpressionMySQL() {
+		Vendor db = Vendor.MySQL;
+		assertEquals("MATCH (some attribute sql) AGAINST (some query)",
+				db.freeTextExpression("some attribute sql", "some query"));
+	}
+
+	public void testFreeTextExpressionSQL92() {
+		Vendor db = Vendor.SQL92;
+		try {
+			db.freeTextExpression("some attribute sql", "some query");
+			fail("Should fail because free text search not in standard SQL92");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		}
+	}
 }


### PR DESCRIPTION
Usage: FILTER http://d2rq.org/function#textMatches (?o, 'some words')

Semantics: given some tokenizer t, the filter matches iff
  t('some words') is a subset of t(?o)
The exact tokenizer implementation depends on the database.

Note that it is also possible for a tokenizer to return zero tokens.
(when the text consists of only stopwords)

Design decisions
- Function namespace: analogous to jena ARQ function namespace
  http://jena.hpl.hp.com/ARQ/function#
- Function name: analogous to SPARQL langMatches function name.
- Used a custom filter function to accomodate additional arguments
  later, for example the text search configuration.

Limitations
- The first argument to the filter function must be a variable,
  arbitrary expressions are not supported.
- The second argument to the filter must be a string,
  expressions or variables are not supported.
- The variable argument must map to one or more database columns.
  Mapping to constant values or sql expressions is currently not supported.
- When the variable maps to a pattern or a URI, only the values
  in the actual SQL columns are searched and matched, not the full URI.
- No boolean expression syntax is supported, even when the underlying
  database does. Reason is we wanted a common interface that works
  similar on multiple databases.
- In PostgreSQL, we currently assume the text search configuration is
  'english'. This could be easily made configurable, though.
- Oracle will only allow free text search on columns for which
  an index of type CTXCAT exists. When no such index exists,
  Oracle will signal an error and the query will not complete.
- MySQL will only allow free text search on columns for which
  an index of type FULLTEXT exists. When no such index exists,
  MySQL will signal an error and the query will not complete.
