### PR TITLE
Fix configuring useAllOptimizations from the mapping file (#204).

### DIFF
--- a/src/de/fuberlin/wiwiss/d2rq/SystemLoader.java
+++ b/src/de/fuberlin/wiwiss/d2rq/SystemLoader.java
@@ -298,7 +298,9 @@ public class SystemLoader {
 	public Mapping getMapping() {
 		if (mapping == null) {
 			mapping = new MapParser(getMappingModel(), getResourceBaseURI()).parse();
-			mapping.configuration().setUseAllOptimizations(fastMode);
+			if (fastMode) {
+				mapping.configuration().setUseAllOptimizations(true);
+			}
 			if (connectedDB != null) {
 				// Hack! We don't want the Database to open another ConnectedDB,
 				// so we check if it's connected to the same DB, and in that case


### PR DESCRIPTION
The configuration option was read from the mapping file, but overwritten
immediately after that. We should only override when the user explicitly
set the --fast option.
