### PR TITLE
Viewing classDefinitionLabels when resolving class URIs

### DIFF
--- a/src/de/fuberlin/wiwiss/d2rq/ResourceDescriber.java
+++ b/src/de/fuberlin/wiwiss/d2rq/ResourceDescriber.java
@@ -71,11 +71,14 @@ public class ResourceDescriber {
 		}
 		result.getBulkUpdateHandler().add(TripleQueryIter.create(qIter));
 		
-		result.getBulkUpdateHandler().add(mapping.getVocabularyModel().getGraph().find(Triple.create(node, Node.ANY, Node.ANY)));
+		result.getBulkUpdateHandler().add(
+			mapping.getVocabularyModel().getGraph().find(
+				Triple.create(node, Node.ANY, Node.ANY)));
 
 		if (!onlyOutgoing) {
-			result.getBulkUpdateHandler().add(mapping.getVocabularyModel().getGraph().find(Triple.create(Node.ANY, Node.ANY, node)));
-			result.getBulkUpdateHandler().add(mapping.getVocabularyModel().getGraph().find(Triple.create(Node.ANY, node, Node.ANY)));
+			result.getBulkUpdateHandler().add(
+				mapping.getVocabularyModel().getGraph().find(
+					Triple.create(Node.ANY, Node.ANY, node)));
 		}
 		
 		if (pingback != null) {

--- a/src/de/fuberlin/wiwiss/d2rq/ResourceDescriber.java
+++ b/src/de/fuberlin/wiwiss/d2rq/ResourceDescriber.java
@@ -71,6 +71,13 @@ public class ResourceDescriber {
 		}
 		result.getBulkUpdateHandler().add(TripleQueryIter.create(qIter));
 		
+		result.getBulkUpdateHandler().add(mapping.getVocabularyModel().getGraph().find(Triple.create(node, Node.ANY, Node.ANY)));
+
+		if (!onlyOutgoing) {
+			result.getBulkUpdateHandler().add(mapping.getVocabularyModel().getGraph().find(Triple.create(Node.ANY, Node.ANY, node)));
+			result.getBulkUpdateHandler().add(mapping.getVocabularyModel().getGraph().find(Triple.create(Node.ANY, node, Node.ANY)));
+		}
+		
 		if (pingback != null) {
 			AlarmClock.get().cancel(pingback);
 		}


### PR DESCRIPTION
As discussed in this [discussion](https://sourceforge.net/p/d2rq-map/mailman/message/30259156/) the classDefinitionLabels directive is not shown when a class URI is resolved. I just integrated the solution proposed by Alex Wilson since it is not included in D2R yet.

In order to get the fix working it is necessary to rebuild D2R. Should I have to include the rebuilded _lib/d2rq-0.8.1.jar_ in the pull?
