### PR TITLE
remove references to revelytix

### DIFF
--- a/doc/resources.html
+++ b/doc/resources.html
@@ -38,7 +38,7 @@
 
 <ul>
   <li><a href="http://d2rq.org/">D2RQ</a></li>
-  <li><a href="http://www.revelytix.com/content/spyder">Revelytix Spyder</a> is a free product for accessing various data sources, including databases, with SPARQL. It supports W3C's R2RML mapping language. Commercial support is available. Revelytix publishes a <a href="http://www.revelytix.com/content/features-comparison-spyder-and-d2rq">comparison of Spyder and D2RQ</a>.</li>
+  <!-- CHECK: this link does not exists anymore: <li><a href="http://www.revelytix.com/content/spyder">Revelytix Spyder</a> is a free product for accessing various data sources, including databases, with SPARQL. It supports W3C's R2RML mapping language. Commercial support is available. Revelytix publishes a <a href="http://www.revelytix.com/content/features-comparison-spyder-and-d2rq">comparison of Spyder and D2RQ</a>.</li> -->
   <li><a href="http://virtuoso.openlinksw.com/wiki/main/Main/VOSSQLRDF">Virtuoso RDF Views</a> has pretty smart rewriting algorithms and also supports Named Graphs and W3C's R2RML mapping language (<a href="http://www.openlinksw.com/dataspace/dav/wiki/Main/VirtR2RML">details</a>). Commercial support is available.</li>
   <li><a href="https://github.com/AKSW/Sparqlify">Sparqlify</a> is an experimental RDB-RDF mapper. It was developed to allow SPARQL access to the OpenStreetMap database. It supports PostgreSQL databases and uses a concise, proprietary, SPARQL-based mapping language. It rewrites any supported SPARQL query into a single SQL query.</li>
   <li><a href="http://mayor2.dia.fi.upm.es/oeg-upm/index.php/en/downloads/9-r2o-odempaster">ODEMapster</a> is a database-to-RDF mapper that uses the R<sub>2</sub>O mapping language.</li>


### PR DESCRIPTION
remove references to revelytix: the provided link (comparison to D2RQ) does not exists anymore